### PR TITLE
Respect a DEBUG Environment in Taiga Config

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,5 +1,6 @@
 # will not allow container to exit even if application exits
 VERSION=4.2.7
+DEBUG=false
 
 # http settings domain, scheme
 TAIGA_HOSTNAME=taiga.localhost

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     TAIGA_EVENTS_HOST=events \
     TAIGA_REDIRECT_TO_SSL=false \
     TAIGA_HOSTNAME=localhost \
-    TAIGA_ENABLE_SSL=false
+    TAIGA_ENABLE_SSL=false \
+    DEBUG=false
 
 # install dependencies
 # download and unpack applications in selected versions

--- a/conf/taiga/conf.json.j2
+++ b/conf/taiga/conf.json.j2
@@ -1,7 +1,7 @@
 {
     "api": "{{ TAIGA_SCHEME }}://{{ TAIGA_HOSTNAME }}/api/v1/",
     "eventsUrl": null,
-    "debug": true,
+    "debug": {{ DEBUG.lower() }},
     "debugInfo": false,
     "defaultLanguage": "{{ TAIGA_DEFAULT_LOCALE }}",
     "publicRegisterEnabled": false,

--- a/conf/taiga/local.py
+++ b/conf/taiga/local.py
@@ -9,7 +9,8 @@
 # https://github.com/taigaio/taiga-back/blob/master/settings/common.py
 
 from .docker import *
+import os
 
 PUBLIC_REGISTER_ENABLED = False
-DEBUG = True
-TEMPLATE_DEBUG = False
+DEBUG = os.getenv('DEBUG', '').lower() == 'true'
+TEMPLATE_DEBUG = os.getenv('DEBUG', '').lower() == 'true'


### PR DESCRIPTION
Setting the DEBUG environment variable to case-insensitive `True` will
enable DEBUG mode in Django and Taiga Front. If it is not `True` DEBUG
mode will be disabled.