### PR TITLE
Expose Project Importer Config Through Env Vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,36 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LDAP_FULL_NAME_ATTRIBUTE="cn" \
     # The fallback authentication method to use if LDAP fails. This will allows users to login with either an LDAP account or a local account. Set to a blank string to prevent logging in with anything other than LDAP.
     LDAP_FALLBACK="normal" \
-    #  Whether or not to save the LDAP password in the local database. If `LDAP_FALLBACK` is set to `normal` this will allow users that have logged in with LDAP before to login even if the LDAP server is unavailable.
+    # Whether or not to save the LDAP password in the local database. If `LDAP_FALLBACK` is set to `normal` this will allow users that have logged in with LDAP before to login even if the LDAP server is unavailable.
     LDAP_SAVE_LOGIN_PASSWORD="true" \
+    # Enable the GitHub project importer
+    TAIGA_IMPORTER_GITHUB_ENABLED="false" \
+    # GitHub importer client ID
+    TAIGA_IMPORTER_GITHUB_CLIENT_ID="" \
+    # GitHub importer client secret
+    TAIGA_IMPORTER_GITHUB_CLIENT_SECRET="" \
+    # Enable the Trello project importer
+    TAIGA_IMPORTER_TRELLO_ENABLED="false" \
+    # Trello importer api key
+    TAIGA_IMPORTER_TRELLO_API_KEY="" \
+    # Trello importer secret key
+    TAIGA_IMPORTER_TRELLO_SECRET_KEY="" \
+    # Enable the JIRA project importer
+    TAIGA_IMPORTER_JIRA_ENABLED="false" \
+    # JIRA importer consumer key
+    TAIGA_IMPORTER_JIRA_CONSUMER_KEY="" \
+    # JIRA importer cert
+    TAIGA_IMPORTER_JIRA_CERT="" \
+    # JIRA importer public cert
+    TAIGA_IMPORTER_JIRA_PUB_CERT="" \
+    # Enable the Asana project importer
+    TAIGA_IMPORTER_ASANA_ENABLED="false" \
+    # Override callback URL for Asana importer. Will be automatically set based on Taiga URL if left blank.
+    TAIGA_IMPORTER_ASANA_CALLBACK_URL="" \
+    # Asana importer app ID
+    TAIGA_IMPORTER_ASANA_APP_ID="" \
+    # Asana importer app secret
+    TAIGA_IMPORTER_ASANA_APP_SECRET="" \
     DEBUG=false \
     TAIGA_UID=1000 \
     TAIGA_GID=1000

--- a/conf/taiga/conf.json.j2
+++ b/conf/taiga/conf.json.j2
@@ -11,5 +11,12 @@
     "termsOfServiceUrl": null,
     "maxUploadFileSize": null,
     {% if TAIGA_LDAP.lower() == 'true' %}"loginFormType": "ldap",{% endif %}
+    {% set comma = joiner(",") %}
+    "importers": [
+        {% if TAIGA_IMPORTER_GITHUB_ENABLED.lower() == 'true' %} {{ comma() }} "github" {% endif %}
+        {% if TAIGA_IMPORTER_TRELLO_ENABLED.lower() == 'true' %} {{ comma() }} "trello" {% endif %}
+        {% if TAIGA_IMPORTER_JIRA_ENABLED.lower() == 'true' %} {{ comma() }} "jira" {% endif %}
+        {% if TAIGA_IMPORTER_ASANA_ENABLED.lower() == 'true' %} {{ comma() }} "asana" {% endif %}
+    ],
     "contribPlugins": []
 }

--- a/conf/taiga/docker-settings.py
+++ b/conf/taiga/docker-settings.py
@@ -83,3 +83,32 @@ LDAP_SAVE_LOGIN_PASSWORD = os.getenv('LDAP_SAVE_LOGIN_PASSWORD', 'true').lower()
 # Fallback on normal authentication method if LDAP auth fails. Set this to ''
 # to disable fallback.
 LDAP_FALLBACK = os.getenv('LDAP_FALLBACK', 'normal')
+
+IMPORTERS["github"] = {
+    "active": os.getenv('TAIGA_IMPORTER_GITHUB_ENABLED', '').lower() == 'true',
+    "client_id": os.getenv('TAIGA_IMPORTER_GITHUB_CLIENT_ID', ''),
+    "client_secret": os.getenv('TAIGA_IMPORTER_GITHUB_CLIENT_SECRET', '')
+}
+
+IMPORTERS["trello"] = {
+    "active": os.getenv('TAIGA_IMPORTER_TRELLO_ENABLED', '').lower() == 'true',
+    "api_key": os.getenv('TAIGA_IMPORTER_TRELLO_API_KEY', ''),
+    "secret_key": os.getenv('TAIGA_IMPORTER_TRELLO_SECRET_KEY', '')
+}
+
+IMPORTERS["jira"] = {
+    "active": os.getenv('TAIGA_IMPORTER_JIRA_ENABLED', '').lower() == 'true',
+    "consumer_key": os.getenv('TAIGA_IMPORTER_JIRA_CONSUMER_KEY', ''),
+    "cert": os.getenv('TAIGA_IMPORTER_JIRA_CERT', ''),
+    "pub_cert": os.getenv('TAIGA_IMPORTER_JIRA_PUB_CERT', '')
+}
+
+default_asana_url = "{}://{}/project/new/import/asana".format(SITES["front"]["scheme"],
+                                                              SITES["front"]["domain"])
+
+IMPORTERS["asana"] = {
+    "active": os.getenv('TAIGA_IMPORTER_ASANA_ENABLED', '').lower() == 'true',
+    "callback_url": os.getenv('TAIGA_IMPORTER_ASANA_CALLBACK_URL') or default_asana_url,
+    "app_id": os.getenv('TAIGA_IMPORTER_ASANA_APP_ID', ''),
+    "app_secret": os.getenv('TAIGA_IMPORTER_ASANA_APP_SECRET', '')
+}


### PR DESCRIPTION
Allows enabling the Taiga project importers for GitHub, Trello, JIRA, and Asana.